### PR TITLE
docs: spell check and trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
   ![ci](https://github.com/vitostamatti/pydes/actions/workflows/ci.yml/badge.svg)
   [![pypi](https://github.com/vitostamatti/pydes/actions/workflows/pypi.yml/badge.svg)](https://github.com/vitostamatti/pydes/actions/workflows/pypi.yml)
-  ![read-the-docs](https://readthedocs.org/projects/pydes/badge/?version=latest)  
-  
+  ![read-the-docs](https://readthedocs.org/projects/pydes/badge/?version=latest)
+
 </div>
 
 
@@ -22,16 +22,15 @@
 
 - **Flexibility:** With **py-des**, users have the flexibility to customize simulation through the usage of predefined and custom `Components`. From simple simulations to complex scenarios involving multiple entities and interactions, **py-des** adapts to diverse use cases with ease.
 
-
 ## Getting Started
 
-To begin using **py-des**, simply install the package via pip (_comming soon_):
+To begin using **py-des**, simply install the package via pip (_coming soon_):
 
 ```bash
 pip install py-des-lib
 ```
 
-First define your main process extending the `Component` and defining a `main` method. 
+First define your main process extending the `Component` and defining a `main` method.
 
 ```py
 from pydes import Component, Simulator
@@ -58,18 +57,14 @@ sim.run()
 
 Start your journey looking at the documentation in the  [quick-start](https://pydes.readthedocs.io/en/latest/quick-start/) section or check out the [examples](https://pydes.readthedocs.io/en/latest/examples/) for guidance on how to create simulation environments, schedule events, and analyze simulation outcomes.
 
-
-
 ## Feedback and Support
 
 If you have any questions, suggestions, or feedback regarding **py-des**, feel free to reach out via GitHub issues or the official communication channels. Your input is invaluable in shaping the future development of the library and ensuring that it meets the needs of its users.
 
-
-
 ## Todos/Ideas
+
 - [ ] more docs
-- [ ] add simulation speed 
-- [ ] add predifined records on components
+- [ ] add simulation speed
+- [ ] add predefined records on components
 - [ ] add components: Server, Source, Sink ...
 - [ ] add a Network module with nodes and links.
-

--- a/docs/examples/02-event-example.md
+++ b/docs/examples/02-event-example.md
@@ -1,6 +1,6 @@
 # Event Example
 
-This example is about showing the usage of the `Event` component. This component can be used as a 
+This example is about showing the usage of the `Event` component. This component can be used as a
 condition that needs to be triggered in order to continue the simulation.
 
 :::pydes.Event
@@ -10,8 +10,7 @@ condition that needs to be triggered in order to continue the simulation.
         show_root_heading: true
         show_bases: false
         show_symbol_type_heading: false
-        
-        
+
 ## Imports
 
 First of all, we import the necessary modules and classes from the `pydes` library. These imports are essential for setting up and running our simulation.

--- a/docs/examples/03-state-example.md
+++ b/docs/examples/03-state-example.md
@@ -1,7 +1,7 @@
 # State Example
 
-In this example, we introduce another Py-DES component called `State`. States are an extension of 
-the events that can take a finite number of values and can be waited for one of them in particular.
+In this example, we introduce another Py-DES component called `State`. States are an extension of
+events that can take a finite number of values and can be waited for one of them in particular.
 
 :::pydes.State
     options:
@@ -10,7 +10,6 @@ the events that can take a finite number of values and can be waited for one of 
         show_root_heading: true
         show_bases: false
         show_symbol_type_heading: false
-        
 
 ## Imports
 
@@ -22,23 +21,23 @@ First of all we import the necessary objects from `pydes`
 
 ## Define Model
 
-For this example we will define a `State` that can take two possible values. 
-Off course this same behaviour could be achieved using simply an `Event`, but 
+For this example we will define a `State` that can take two possible values.
+Of course this same behavior could be achieved using simply an `Event`, but
 the idea is to showcase the usage of the `State` component.
 
 ```py linenums="1"
 --8<-- "./docs/code/03_state_example.py:example-1"
 ```
 
-There is one process that will stop its execution until the state 
+There is one process that will stop its execution until the state
 is set to a specific value.
 
 ```py linenums="1"
 --8<-- "./docs/code/03_state_example.py:example-2"
 ```
 
-The other process is going to be responsible of changing the `State` into 
-its new value. This will be done after a delay and thus delaying the advance 
+The other process is going to be responsible of changing the `State` into
+its new value. This will be done after a delay and thus delaying the advance
 of the other process until the change in the state.
 
 ```py linenums="1"
@@ -47,8 +46,8 @@ of the other process until the change in the state.
 
 ## Run Simulation
 
-With all this defined. We build the `Simulator` and the components involved. We schedule 
-both procesess and then start the simulation.
+With all this defined. We build the `Simulator` and the components involved. We schedule
+both processes and then start the simulation.
 
 ```bash
 --8<-- "./docs/code/03_state_example.py:run"

--- a/docs/examples/04-queue-example.md
+++ b/docs/examples/04-queue-example.md
@@ -1,6 +1,6 @@
 # Queue Example
 
-In this example, we introduce another Py-DES component called `Queue`. Queues are an essential 
+In this example, we introduce another Py-DES component called `Queue`. Queues are an essential
 part of almost every system in real life.
 
 :::pydes.Queue
@@ -10,7 +10,6 @@ part of almost every system in real life.
         show_root_heading: true
         show_bases: false
         show_symbol_type_heading: false
-        
 
 ## Imports
 
@@ -22,14 +21,14 @@ First of all we import the necessary objects from `pydes`
 
 ## Define Model
 
-For this example we define a first process that is going to `put` elements into 
+For this example we define a first process that is going to `put` elements into
 the `Queue` with a time interval.
 
 ```py linenums="1"
 --8<-- "./docs/code/04_queue_example.py:example-1"
 ```
 
-There is another process running that will try `get` elements from the same `Queue` 
+There is another process running that will try `get` elements from the same `Queue`
 and wait if it is empty.
 
 ```py linenums="1"
@@ -38,8 +37,8 @@ and wait if it is empty.
 
 ## Run Simulation
 
-With all this defined. We build the `Simulator` and the components involved. We schedule 
-both procesess and then start the simulation.
+With all this defined. We build the `Simulator` and the components involved. We schedule
+both processes and then start the simulation.
 
 ```bash
 --8<-- "./docs/code/04_queue_example.py:run"

--- a/docs/examples/05-resource-example.md
+++ b/docs/examples/05-resource-example.md
@@ -7,8 +7,7 @@
         show_root_heading: true
         show_bases: false
         show_symbol_type_heading: false
-        
-            
+
 ## Imports
 
 ```py linenums="1"

--- a/docs/examples/06-container-example.md
+++ b/docs/examples/06-container-example.md
@@ -7,7 +7,6 @@
         show_root_heading: true
         show_bases: false
         show_symbol_type_heading: false
-        
 
 ## Imports
 

--- a/docs/examples/07-store-example.md
+++ b/docs/examples/07-store-example.md
@@ -1,6 +1,5 @@
 # Store Example
 
-
 :::pydes.Store
     options:
         show_object_full_path: false
@@ -8,7 +7,6 @@
         show_root_heading: true
         show_bases: false
         show_symbol_type_heading: false
-        
 
 ## Imports
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,19 +1,19 @@
 # Examples
 
-In this section you an find a handful of examples using `Py-DES` for modeling multiple scenarios of 
+In this section you an find a handful of examples using `Py-DES` for modeling multiple scenarios of
 different complexity.
 
-The idea is not to showcase a full real world example, that could come soon in a separate code repository, 
+The idea is not to showcase a full real world example, that could come soon in a separate code repository,
 but to cover the usage of all the components and capabilities that `Py-DES` has to offer.
 
 ## Contents
 
-* [Process Example](01-process-example.md) 
-* [Event Example](02-event-example.md) 
-* [State Example](03-state-example.md) 
-* [Queue Example](04-queue-example.md) 
-* [Resource Example](05-resource-example.md) 
-* [Container Example](06-container-example.md) 
-* [Store Example](07-store-example.md) 
-* [Date Time Example](08-datetime-example.md) 
+* [Process Example](01-process-example.md)
+* [Event Example](02-event-example.md)
+* [State Example](03-state-example.md)
+* [Queue Example](04-queue-example.md)
+* [Resource Example](05-resource-example.md)
+* [Container Example](06-container-example.md)
+* [Store Example](07-store-example.md)
+* [Date Time Example](08-datetime-example.md)
 * more coming soon...

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,13 +16,13 @@
 
 ## Getting Started
 
-To begin using **py-des**, simply install the package via pip (_comming soon_):
+To begin using **py-des**, simply install the package via pip (_coming soon_):
 
 ```bash
 pip install py-des-lib
 ```
 
-First define your main process extending the `Component` and defining a `main` method. 
+First define your main process extending the `Component` and defining a `main` method.
 
 ```py linenums="1"
 from pydes import Component, Simulator
@@ -49,7 +49,7 @@ sim.run()
 
 If you are interested in learning about what is Discrete Event Simulation you can start your journey in the [overview](overview.md) section.
 
-If you want some hands-on leraning experience, you can check out the [quick-start](quick-start.md) and [examples](./examples/index.md) sections for guidance on how to create simulation environments, schedule events, and analyze simulation outcomes.
+If you want some hands-on learning experience, you can check out the [quick-start](quick-start.md) and [examples](./examples/index.md) sections for guidance on how to create simulation environments, schedule events, and analyze simulation outcomes.
 
 
 ## Feedback and Support

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,5 @@
 # Overview
 
-
 ## Introduction
 
 [Discrete Event Simulation](https://en.wikipedia.org/wiki/Discrete-event_simulation) (DES) is a powerful modeling technique that enables the emulation of real-world systems by simulating individual events as they occur over time. In data science, DES serves as a critical tool for modeling dynamic systems and processes, aiding in understanding their behavior, optimizing performance, and making informed decisions.
@@ -13,17 +12,17 @@ Discrete Event Simulation (DES) operates on the premise of modeling dynamic syst
 
 ### Fundamental Concepts of DES
 
-At its core, DES revolves around **entities**, **events**, the simulation **clock**, and **queues**. 
+At its core, DES revolves around **entities**, **events**, the simulation **clock**, and **queues**.
 
-- Entities represent the objects or elements within the system under observation. 
-- Events, triggered by entities, denote occurrences that affect the system's state or condition. 
-- The simulation clock marks discrete instances when these events transpire, driving the progression of time within the simulated environment. 
+- Entities represent the objects or elements within the system under observation.
+- Events, triggered by entities, denote occurrences that affect the system's state or condition.
+- The simulation clock marks discrete instances when these events transpire, driving the progression of time within the simulated environment.
 - Queues play a pivotal role in managing and processing entities, representing waiting lines or buffers where entities await processing or service.
 
-If we go one abstraction layer up, common DES components can be classified into **sources**, **servers** (with or withtout queues) and **sinks**.
+If we go one abstraction layer up, common DES components can be classified into **sources**, **servers** (with or without queues) and **sinks**.
 - Sources are responsible of producing entities and inserting them into the simulating system. Times between arrival and amount of entities per arrival are common parameters of sources.
 - Servers are in charge of delaying entities in the system for a given time period defined usually as a processing time.
-- Sinks are used to remove entities from the simlating system and are useful to collect information about times spend by entities and performance of the overall system.
+- Sinks are used to remove entities from the simulating system and are useful to collect information about times spend by entities and performance of the overall system.
 
 <figure markdown>
   ![Logo](./assets/des-example.png){ width="500" }

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,6 +1,6 @@
 # Discrete Event Simulation in Python with Py-DES
 
-In this sectrion we’ll explore the Py-DES basic ojjects and its main capabilities. 
+In this section we’ll explore the Py-DES basic objects and its main capabilities.
 
 ## Setup
 


### PR DESCRIPTION
1.  Check spelling in `.md` files using `aspell`.
2.  Remove end-of-line whitespace.